### PR TITLE
Fix dataset attribute usage for newer torchvision

### DIFF
--- a/cifar100-class-incremental/class_incremental_cifar100.py
+++ b/cifar100-class-incremental/class_incremental_cifar100.py
@@ -95,10 +95,20 @@ dictionary_size     = 500
 top1_acc_list_cumul = np.zeros((int(args.num_classes/args.nb_cl),3,args.nb_runs))
 top1_acc_list_ori   = np.zeros((int(args.num_classes/args.nb_cl),3,args.nb_runs))
 
-X_train_total = np.array(trainset.train_data)
-Y_train_total = np.array(trainset.train_labels)
-X_valid_total = np.array(testset.test_data)
-Y_valid_total = np.array(testset.test_labels)
+# In torchvision >=0.3 the CIFAR datasets use `data` and `targets` instead of
+# the deprecated `train_data`/`train_labels` and `test_data`/`test_labels`
+# attributes.  Using the old attribute names with recent versions results in the
+# original labels being returned by the dataset, which later produces training
+# targets outside the valid range and triggers CUDA errors.  The following lines
+# access the contemporary attributes while keeping backward compatibility by
+# falling back to the legacy names if required.
+
+# Training data and labels
+X_train_total = np.array(getattr(trainset, 'data', trainset.train_data))
+Y_train_total = np.array(getattr(trainset, 'targets', trainset.train_labels))
+# Validation data and labels
+X_valid_total = np.array(getattr(testset, 'data', testset.test_data))
+Y_valid_total = np.array(getattr(testset, 'targets', testset.test_labels))
 
 # Launch the different runs
 for iteration_total in range(args.nb_runs):
@@ -195,8 +205,16 @@ for iteration_total in range(args.nb_runs):
         map_Y_train = np.array([order_list.index(i) for i in Y_train])
         map_Y_valid_cumul = np.array([order_list.index(i) for i in Y_valid_cumul])
         ############################################################
-        trainset.train_data = X_train.astype('uint8')
-        trainset.train_labels = map_Y_train
+        # Update dataset with the current training data/labels.  Newer versions of
+        # torchvision expect the attributes `data` and `targets` whereas older
+        # releases use `train_data` and `train_labels`.  Assign to both when
+        # available to remain compatible across versions.
+        trainset.data = X_train.astype('uint8')
+        trainset.targets = map_Y_train.tolist()
+        if hasattr(trainset, 'train_data'):
+            trainset.train_data = trainset.data
+        if hasattr(trainset, 'train_labels'):
+            trainset.train_labels = trainset.targets
         if iteration > start_iter and args.rs_ratio > 0 and scale_factor > 1:
             print("Weights from sampling:", rs_sample_weights)
             index1 = np.where(rs_sample_weights>1)[0]
@@ -208,8 +226,13 @@ for iteration_total in range(args.nb_runs):
         else:
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
                 shuffle=True, num_workers=2)
-        testset.test_data = X_valid_cumul.astype('uint8')
-        testset.test_labels = map_Y_valid_cumul
+        # Likewise update the evaluation dataset
+        testset.data = X_valid_cumul.astype('uint8')
+        testset.targets = map_Y_valid_cumul.tolist()
+        if hasattr(testset, 'test_data'):
+            testset.test_data = testset.data
+        if hasattr(testset, 'test_labels'):
+            testset.test_labels = testset.targets
         testloader = torch.utils.data.DataLoader(testset, batch_size=test_batch_size,
             shuffle=False, num_workers=2)
         print('Max and Min of train labels: {}, {}'.format(min(map_Y_train), max(map_Y_train)))
@@ -248,11 +271,15 @@ for iteration_total in range(args.nb_runs):
         print('Updating exemplar set...')
         for iter_dico in range(last_iter*args.nb_cl, (iteration+1)*args.nb_cl):
             # Possible exemplars in the feature space and projected on the L2 sphere
-            evalset.test_data = prototypes[iter_dico].astype('uint8')
-            evalset.test_labels = np.zeros(evalset.test_data.shape[0]) #zero labels
+            evalset.data = prototypes[iter_dico].astype('uint8')
+            evalset.targets = np.zeros(evalset.data.shape[0]).tolist()  # zero labels
+            if hasattr(evalset, 'test_data'):
+                evalset.test_data = evalset.data
+            if hasattr(evalset, 'test_labels'):
+                evalset.test_labels = evalset.targets
             evalloader = torch.utils.data.DataLoader(evalset, batch_size=eval_batch_size,
                 shuffle=False, num_workers=2)
-            num_samples = evalset.test_data.shape[0]            
+            num_samples = evalset.data.shape[0]
             mapped_prototypes = compute_features(tg_feature_model, evalloader, num_samples, num_features)
             D = mapped_prototypes.T
             D = D/np.linalg.norm(D,axis=0)
@@ -286,16 +313,22 @@ for iteration_total in range(args.nb_runs):
                 current_cl = order[range(iteration2*args.nb_cl,(iteration2+1)*args.nb_cl)]
 
                 # Collect data in the feature space for each class
-                evalset.test_data = prototypes[iteration2*args.nb_cl+iter_dico].astype('uint8')
-                evalset.test_labels = np.zeros(evalset.test_data.shape[0]) #zero labels
+                evalset.data = prototypes[iteration2*args.nb_cl+iter_dico].astype('uint8')
+                evalset.targets = np.zeros(evalset.data.shape[0]).tolist()  # zero labels
+                if hasattr(evalset, 'test_data'):
+                    evalset.test_data = evalset.data
+                if hasattr(evalset, 'test_labels'):
+                    evalset.test_labels = evalset.targets
                 evalloader = torch.utils.data.DataLoader(evalset, batch_size=eval_batch_size,
                     shuffle=False, num_workers=2)
-                num_samples = evalset.test_data.shape[0]
+                num_samples = evalset.data.shape[0]
                 mapped_prototypes = compute_features(tg_feature_model, evalloader, num_samples, num_features)
                 D = mapped_prototypes.T
                 D = D/np.linalg.norm(D,axis=0)
                 # Flipped version also
-                evalset.test_data = prototypes[iteration2*args.nb_cl+iter_dico][:,:,:,::-1].astype('uint8')
+                evalset.data = prototypes[iteration2*args.nb_cl+iter_dico][:,:,:,::-1].astype('uint8')
+                if hasattr(evalset, 'test_data'):
+                    evalset.test_data = evalset.data
                 evalloader = torch.utils.data.DataLoader(evalset, batch_size=eval_batch_size,
                     shuffle=False, num_workers=2)
                 mapped_prototypes2 = compute_features(tg_feature_model, evalloader, num_samples, num_features)
@@ -324,8 +357,12 @@ for iteration_total in range(args.nb_runs):
         # Calculate validation error of model on the first nb_cl classes:
         map_Y_valid_ori = np.array([order_list.index(i) for i in Y_valid_ori])
         print('Computing accuracy on the original batch of classes...')
-        evalset.test_data = X_valid_ori.astype('uint8')
-        evalset.test_labels = map_Y_valid_ori
+        evalset.data = X_valid_ori.astype('uint8')
+        evalset.targets = map_Y_valid_ori.tolist()
+        if hasattr(evalset, 'test_data'):
+            evalset.test_data = evalset.data
+        if hasattr(evalset, 'test_labels'):
+            evalset.test_labels = evalset.targets
         evalloader = torch.utils.data.DataLoader(evalset, batch_size=eval_batch_size,
                 shuffle=False, num_workers=2)
         ori_acc = compute_accuracy(tg_model, tg_feature_model, current_means, evalloader)
@@ -334,8 +371,12 @@ for iteration_total in range(args.nb_runs):
         # Calculate validation error of model on the cumul of classes:
         map_Y_valid_cumul = np.array([order_list.index(i) for i in Y_valid_cumul])
         print('Computing cumulative accuracy...')
-        evalset.test_data = X_valid_cumul.astype('uint8')
-        evalset.test_labels = map_Y_valid_cumul
+        evalset.data = X_valid_cumul.astype('uint8')
+        evalset.targets = map_Y_valid_cumul.tolist()
+        if hasattr(evalset, 'test_data'):
+            evalset.test_data = evalset.data
+        if hasattr(evalset, 'test_labels'):
+            evalset.test_labels = evalset.targets
         evalloader = torch.utils.data.DataLoader(evalset, batch_size=eval_batch_size,
                 shuffle=False, num_workers=2)        
         cumul_acc = compute_accuracy(tg_model, tg_feature_model, current_means, evalloader)


### PR DESCRIPTION
## Summary
- access CIFAR100 data/labels via `data` and `targets` with fallback to legacy attributes
- update training and evaluation datasets accordingly to keep labels in range

## Testing
- `python -m py_compile cifar100-class-incremental/class_incremental_cifar100.py cifar100-class-incremental/class_incremental_cosine_cifar100.py cifar100-class-incremental/eval_cumul_acc.py`


------
https://chatgpt.com/codex/tasks/task_e_688fcb5806fc8322ba0b3c76b6d328cd