### PR TITLE
Ensure CIFAR dataset attribute compatibility

### DIFF
--- a/cifar100-class-incremental/class_incremental_cosine_cifar100.py
+++ b/cifar100-class-incremental/class_incremental_cosine_cifar100.py
@@ -131,10 +131,24 @@ top1_acc_list_ori   = np.zeros((int(args.num_classes/args.nb_cl),3,args.nb_runs)
 # behind using `data`/`targets` instead of the deprecated attribute names.  Here
 # we apply the same logic and fall back to the legacy attributes when running on
 # older versions of torchvision.
-X_train_total = np.array(getattr(trainset, 'data', trainset.train_data))
-Y_train_total = np.array(getattr(trainset, 'targets', trainset.train_labels))
-X_valid_total = np.array(getattr(testset, 'data', testset.test_data))
-Y_valid_total = np.array(getattr(testset, 'targets', testset.test_labels))
+
+
+def _compat_attr(ds, primary, legacy):
+    """Return ``ds.primary`` if present otherwise ``ds.legacy``.
+
+    Keeps dataset access compatible with both legacy and current versions of
+    torchvision where the CIFAR datasets switched from ``train_data``/
+    ``train_labels`` and ``test_data``/``test_labels`` to ``data`` and
+    ``targets``.
+    """
+
+    return getattr(ds, primary, getattr(ds, legacy))
+
+
+X_train_total = np.array(_compat_attr(trainset, 'data', 'train_data'))
+Y_train_total = np.array(_compat_attr(trainset, 'targets', 'train_labels'))
+X_valid_total = np.array(_compat_attr(testset, 'data', 'test_data'))
+Y_valid_total = np.array(_compat_attr(testset, 'targets', 'test_labels'))
 
 # Launch the different runs
 for iteration_total in range(args.nb_runs):
@@ -279,7 +293,7 @@ for iteration_total in range(args.nb_runs):
                 cls_indices = np.array([i == cls_idx  for i in map_Y_train])
                 assert(len(np.where(cls_indices==1)[0])==dictionary_size)
                 evalset.data = X_train[cls_indices].astype('uint8')
-                evalset.targets = np.zeros(evalset.data.shape[0]).tolist()  # zero labels
+                evalset.targets = np.zeros(evalset.data.shape[0])  # zero labels
                 if hasattr(evalset, 'test_data'):
                     evalset.test_data = evalset.data
                 if hasattr(evalset, 'test_labels'):
@@ -304,7 +318,7 @@ for iteration_total in range(args.nb_runs):
         # Update dataset with current training data/labels (supporting both
         # legacy and recent torchvision versions).
         trainset.data = X_train.astype('uint8')
-        trainset.targets = map_Y_train.tolist()
+        trainset.targets = map_Y_train
         if hasattr(trainset, 'train_data'):
             trainset.train_data = trainset.data
         if hasattr(trainset, 'train_labels'):
@@ -321,7 +335,7 @@ for iteration_total in range(args.nb_runs):
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
                 shuffle=True, num_workers=2)
         testset.data = X_valid_cumul.astype('uint8')
-        testset.targets = map_Y_valid_cumul.tolist()
+        testset.targets = map_Y_valid_cumul
         if hasattr(testset, 'test_data'):
             testset.test_data = testset.data
         if hasattr(testset, 'test_labels'):
@@ -406,7 +420,7 @@ for iteration_total in range(args.nb_runs):
         for iter_dico in range(last_iter*args.nb_cl, (iteration+1)*args.nb_cl):
             # Possible exemplars in the feature space and projected on the L2 sphere
             evalset.data = prototypes[iter_dico].astype('uint8')
-            evalset.targets = np.zeros(evalset.data.shape[0]).tolist()  # zero labels
+            evalset.targets = np.zeros(evalset.data.shape[0])  # zero labels
             if hasattr(evalset, 'test_data'):
                 evalset.test_data = evalset.data
             if hasattr(evalset, 'test_labels'):
@@ -448,7 +462,7 @@ for iteration_total in range(args.nb_runs):
 
                 # Collect data in the feature space for each class
                 evalset.data = prototypes[iteration2*args.nb_cl+iter_dico].astype('uint8')
-                evalset.targets = np.zeros(evalset.data.shape[0]).tolist()  # zero labels
+                evalset.targets = np.zeros(evalset.data.shape[0])  # zero labels
                 if hasattr(evalset, 'test_data'):
                     evalset.test_data = evalset.data
                 if hasattr(evalset, 'test_labels'):
@@ -492,7 +506,7 @@ for iteration_total in range(args.nb_runs):
         map_Y_valid_ori = np.array([order_list.index(i) for i in Y_valid_ori])
         print('Computing accuracy on the original batch of classes...')
         evalset.data = X_valid_ori.astype('uint8')
-        evalset.targets = map_Y_valid_ori.tolist()
+        evalset.targets = map_Y_valid_ori
         if hasattr(evalset, 'test_data'):
             evalset.test_data = evalset.data
         if hasattr(evalset, 'test_labels'):
@@ -506,7 +520,7 @@ for iteration_total in range(args.nb_runs):
         map_Y_valid_cumul = np.array([order_list.index(i) for i in Y_valid_cumul])
         print('Computing cumulative accuracy...')
         evalset.data = X_valid_cumul.astype('uint8')
-        evalset.targets = map_Y_valid_cumul.tolist()
+        evalset.targets = map_Y_valid_cumul
         if hasattr(evalset, 'test_data'):
             evalset.test_data = evalset.data
         if hasattr(evalset, 'test_labels'):

--- a/cifar100-class-incremental/eval_cumul_acc.py
+++ b/cifar100-class-incremental/eval_cumul_acc.py
@@ -53,15 +53,25 @@ transform_test = transforms.Compose([
 ])
 evalset = torchvision.datasets.CIFAR100(root='./data', train=False,
                                        download=False, transform=transform_test)
-# In recent versions of torchvision the evaluation data/labels are stored in
-# `data` and `targets`.  Fall back to the old attribute names for backward
-# compatibility.
-input_data = getattr(evalset, 'data', evalset.test_data)
-input_labels = getattr(evalset, 'targets', evalset.test_labels)
+
+
+def _compat_attr(ds, primary, legacy):
+    """Return ``ds.primary`` if present otherwise ``ds.legacy``.
+
+    Mirrors the helper used during training to seamlessly access dataset
+    attributes regardless of the torchvision version.
+    """
+
+    return getattr(ds, primary, getattr(ds, legacy))
+
+
+# Retrieve the evaluation data/labels in a version-agnostic fashion
+input_data = np.array(_compat_attr(evalset, 'data', 'test_data'))
+input_labels = np.array(_compat_attr(evalset, 'targets', 'test_labels'))
 map_input_labels = np.array([order_list.index(i) for i in input_labels])
-# Update the dataset with mapped labels to ensure consistency.
+# Update the dataset with mapped labels to ensure consistency across versions
 evalset.data = input_data
-evalset.targets = map_input_labels.tolist()
+evalset.targets = map_input_labels
 if hasattr(evalset, 'test_data'):
     evalset.test_data = evalset.data
 if hasattr(evalset, 'test_labels'):
@@ -87,7 +97,7 @@ for iteration in range(start_iter, int(100/nb_cl)):
     current_means = class_means[:, order[:(iteration+1)*nb_cl]]
     indices = np.array([i in range(0, (iteration+1)*nb_cl) for i in map_input_labels])
     evalset.data = input_data[indices]
-    evalset.targets = map_input_labels[indices].tolist()
+    evalset.targets = map_input_labels[indices]
     if hasattr(evalset, 'test_data'):
         evalset.test_data = evalset.data
     if hasattr(evalset, 'test_labels'):


### PR DESCRIPTION
## Summary
- centralize compatibility handling for CIFAR dataset attributes to avoid off-range labels across torchvision versions
- update dataset assignments to reuse returned arrays in training and evaluation scripts

## Testing
- `python -m py_compile cifar100-class-incremental/class_incremental_cifar100.py cifar100-class-incremental/class_incremental_cosine_cifar100.py cifar100-class-incremental/eval_cumul_acc.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd3f2bb00832289fcf0429b32c22e