### PR TITLE
Guard dataset attribute access

### DIFF
--- a/cifar100-class-incremental/class_incremental_cifar100.py
+++ b/cifar100-class-incremental/class_incremental_cifar100.py
@@ -114,7 +114,11 @@ def _compat_attr(ds, primary, legacy):
     exist.
     """
 
-    return getattr(ds, primary, getattr(ds, legacy))
+    if hasattr(ds, primary):
+        return getattr(ds, primary)
+    if hasattr(ds, legacy):
+        return getattr(ds, legacy)
+    raise AttributeError(f"{type(ds).__name__} lacks '{primary}' and '{legacy}'")
 
 # Training data and labels
 X_train_total = np.array(_compat_attr(trainset, 'data', 'train_data'))

--- a/cifar100-class-incremental/class_incremental_cosine_cifar100.py
+++ b/cifar100-class-incremental/class_incremental_cosine_cifar100.py
@@ -142,7 +142,11 @@ def _compat_attr(ds, primary, legacy):
     ``targets``.
     """
 
-    return getattr(ds, primary, getattr(ds, legacy))
+    if hasattr(ds, primary):
+        return getattr(ds, primary)
+    if hasattr(ds, legacy):
+        return getattr(ds, legacy)
+    raise AttributeError(f"{type(ds).__name__} lacks '{primary}' and '{legacy}'")
 
 
 X_train_total = np.array(_compat_attr(trainset, 'data', 'train_data'))

--- a/cifar100-class-incremental/eval_cumul_acc.py
+++ b/cifar100-class-incremental/eval_cumul_acc.py
@@ -62,7 +62,11 @@ def _compat_attr(ds, primary, legacy):
     attributes regardless of the torchvision version.
     """
 
-    return getattr(ds, primary, getattr(ds, legacy))
+    if hasattr(ds, primary):
+        return getattr(ds, primary)
+    if hasattr(ds, legacy):
+        return getattr(ds, legacy)
+    raise AttributeError(f"{type(ds).__name__} lacks '{primary}' and '{legacy}'")
 
 
 # Retrieve the evaluation data/labels in a version-agnostic fashion


### PR DESCRIPTION
## Summary
- Ensure `_compat_attr` verifies dataset attributes before access
- Raise clear `AttributeError` when neither primary nor legacy attributes exist

## Testing
- `python -m py_compile cifar100-class-incremental/class_incremental_cifar100.py cifar100-class-incremental/class_incremental_cosine_cifar100.py cifar100-class-incremental/eval_cumul_acc.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd8cf9f148322bfd406827b771023