### PR TITLE
Fix device mismatch in feature utilities

### DIFF
--- a/utils_incremental/compute_accuracy.py
+++ b/utils_incremental/compute_accuracy.py
@@ -21,6 +21,10 @@ from utils_pytorch import *
 def compute_accuracy(tg_model, tg_feature_model, class_means, evalloader, scale=None, print_info=True, device=None):
     if device is None:
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    # Move models to the desired device to prevent device mismatch errors when
+    # inputs are on GPU.
+    tg_model = tg_model.to(device)
+    tg_feature_model = tg_feature_model.to(device)
     tg_model.eval()
     tg_feature_model.eval()
 
@@ -43,9 +47,11 @@ def compute_accuracy(tg_model, tg_feature_model, class_means, evalloader, scale=
             outputs = tg_model(inputs)
             outputs = F.softmax(outputs, dim=1)
             if scale is not None:
-                assert(scale.shape[0] == 1)
-                assert(outputs.shape[1] == scale.shape[1])
-                outputs = outputs / scale.repeat(outputs.shape[0], 1).type(torch.FloatTensor).to(device)
+                assert scale.shape[0] == 1
+                assert outputs.shape[1] == scale.shape[1]
+                outputs = outputs / scale.repeat(outputs.shape[0], 1).type(
+                    torch.FloatTensor
+                ).to(device)
             _, predicted = outputs.max(1)
             correct += predicted.eq(targets).sum().item()
 

--- a/utils_incremental/compute_confusion_matrix.py
+++ b/utils_incremental/compute_confusion_matrix.py
@@ -21,6 +21,10 @@ from utils_pytorch import *
 def compute_confusion_matrix(tg_model, tg_feature_model, class_means, evalloader, print_info=False, device=None):
     if device is None:
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    # Move models to the target device so their weights match the input
+    # tensors' device type.
+    tg_model = tg_model.to(device)
+    tg_feature_model = tg_feature_model.to(device)
     tg_model.eval()
     tg_feature_model.eval()
 

--- a/utils_incremental/compute_features.py
+++ b/utils_incremental/compute_features.py
@@ -23,6 +23,9 @@ from utils_pytorch import *
 def compute_features(tg_feature_model, evalloader, num_samples, num_features, device=None):
     if device is None:
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    # Ensure the feature extractor operates on the correct device to avoid
+    # mismatched tensor/weight types when the inputs are on GPU.
+    tg_feature_model = tg_feature_model.to(device)
     tg_feature_model.eval()
 
     #evalset = torchvision.datasets.CIFAR100(root='./data', train=False,
@@ -37,7 +40,9 @@ def compute_features(tg_feature_model, evalloader, num_samples, num_features, de
     with torch.no_grad():
         for inputs, targets in evalloader:
             inputs = inputs.to(device)
-            features[start_idx:start_idx+inputs.shape[0], :] = np.squeeze(tg_feature_model(inputs))
-            start_idx = start_idx+inputs.shape[0]
+            features[start_idx:start_idx+inputs.shape[0], :] = np.squeeze(
+                tg_feature_model(inputs)
+            )
+            start_idx = start_idx + inputs.shape[0]
     assert(start_idx==num_samples)
     return features


### PR DESCRIPTION
## Summary
- Ensure feature extraction models run on the correct device in compute_features
- Move models to the target device in compute_accuracy and compute_confusion_matrix

## Testing
- `python -m py_compile utils_incremental/compute_features.py utils_incremental/compute_accuracy.py utils_incremental/compute_confusion_matrix.py`
- `python - <<'PY'
import torch, torch.nn as nn
from utils_incremental.compute_features import compute_features
from utils_incremental.compute_accuracy import compute_accuracy
from utils_incremental.compute_confusion_matrix import compute_confusion_matrix
from torch.utils.data import DataLoader, TensorDataset

# Dummy dataset
inputs = torch.randn(8, 3, 32, 32)
labels = torch.randint(0, 10, (8,))
loader = DataLoader(TensorDataset(inputs, labels), batch_size=4)

# Dummy model
class DummyModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.feat = nn.Sequential(
            nn.Flatten(),
            nn.Linear(3*32*32, 16),
            nn.ReLU()
        )
        self.fc = nn.Linear(16, 10)
    def forward(self, x):
        x = self.feat(x)
        return self.fc(x)

tg_model = DummyModel()
# Feature extractor: all layers except last FC
from torch import nn as tnn
# In our design, sequential features are in tg_model.feat already.
# Compose to mimic typical behaviour

tg_feature_model = nn.Sequential(*list(tg_model.children())[:-1])

# Use GPU if available
features = compute_features(tg_feature_model, loader, num_samples=8, num_features=16)
print('features shape', features.shape)

# Create random class means
class_means = torch.randn(16, 10, 2)

acc = compute_accuracy(tg_model, tg_feature_model, class_means, loader, print_info=False)
print('acc', acc)

cm = compute_confusion_matrix(tg_model, tg_feature_model, class_means, loader)
print('cm shape', cm.shape)
PY` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6890a3547b788322aa46b5159f1dddd3