### PR TITLE
Add collate function for soft targets

### DIFF
--- a/cifar100-class-incremental/class_incremental_cifar100.py
+++ b/cifar100-class-incremental/class_incremental_cifar100.py
@@ -26,6 +26,7 @@ from utils_incremental.compute_features import compute_features
 from utils_incremental.compute_accuracy import compute_accuracy
 from utils_incremental.compute_confusion_matrix import compute_confusion_matrix
 from utils_incremental.incremental_train_and_eval import incremental_train_and_eval
+from utils_incremental.dataset import collate_with_soft_targets
 
 ######### Modifiable Settings ##########
 parser = argparse.ArgumentParser()
@@ -222,10 +223,10 @@ for iteration_total in range(args.nb_runs):
             assert((index1==index2).all())
             train_sampler = torch.utils.data.sampler.WeightedRandomSampler(rs_sample_weights, rs_num_samples)
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size, \
-                shuffle=False, sampler=train_sampler, num_workers=2)            
+                shuffle=False, sampler=train_sampler, num_workers=2, collate_fn=collate_with_soft_targets)
         else:
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
-                shuffle=True, num_workers=2)
+                shuffle=True, num_workers=2, collate_fn=collate_with_soft_targets)
         # Likewise update the evaluation dataset
         testset.data = X_valid_cumul.astype('uint8')
         testset.targets = map_Y_valid_cumul.tolist()

--- a/cifar100-class-incremental/class_incremental_cosine_cifar100.py
+++ b/cifar100-class-incremental/class_incremental_cosine_cifar100.py
@@ -32,6 +32,7 @@ from utils_incremental.incremental_train_and_eval_MS import incremental_train_an
 from utils_incremental.incremental_train_and_eval_LF import incremental_train_and_eval_LF
 from utils_incremental.incremental_train_and_eval_MR_LF import incremental_train_and_eval_MR_LF
 from utils_incremental.incremental_train_and_eval_AMR_LF import incremental_train_and_eval_AMR_LF
+from utils_incremental.dataset import collate_with_soft_targets
 
 ######### Modifiable Settings ##########
 parser = argparse.ArgumentParser()
@@ -316,10 +317,10 @@ for iteration_total in range(args.nb_runs):
             assert((index1==index2).all())
             train_sampler = torch.utils.data.sampler.WeightedRandomSampler(rs_sample_weights, rs_num_samples)
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size, \
-                shuffle=False, sampler=train_sampler, num_workers=2)            
+                shuffle=False, sampler=train_sampler, num_workers=2, collate_fn=collate_with_soft_targets)
         else:
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
-                shuffle=True, num_workers=2)
+                shuffle=True, num_workers=2, collate_fn=collate_with_soft_targets)
         testset.data = X_valid_cumul.astype('uint8')
         testset.targets = map_Y_valid_cumul.tolist()
         if hasattr(testset, 'test_data'):

--- a/imagenet-class-incremental/cbf_class_incremental_cosine_imagenet.py
+++ b/imagenet-class-incremental/cbf_class_incremental_cosine_imagenet.py
@@ -34,6 +34,7 @@ from utils_incremental.incremental_train_and_eval_MS import incremental_train_an
 from utils_incremental.incremental_train_and_eval_LF import incremental_train_and_eval_LF
 from utils_incremental.incremental_train_and_eval_MR_LF import incremental_train_and_eval_MR_LF
 from utils_incremental.incremental_train_and_eval_AMR_LF import incremental_train_and_eval_AMR_LF
+from utils_incremental.dataset import collate_with_soft_targets
 
 ######### Modifiable Settings ##########
 parser = argparse.ArgumentParser()
@@ -353,12 +354,14 @@ for iteration_total in range(args.nb_runs):
             #trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size, \
             #    shuffle=False, sampler=train_sampler, num_workers=2)
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size, \
-                shuffle=False, sampler=train_sampler, num_workers=args.num_workers, pin_memory=True)             
+                shuffle=False, sampler=train_sampler, num_workers=args.num_workers, pin_memory=True,
+                collate_fn=collate_with_soft_targets)
         else:
             #trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
             #    shuffle=True, num_workers=2)
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
-                shuffle=True, num_workers=args.num_workers, pin_memory=True)
+                shuffle=True, num_workers=args.num_workers, pin_memory=True,
+                collate_fn=collate_with_soft_targets)
         #testset.test_data = X_valid_cumul.astype('uint8')
         #testset.test_labels = map_Y_valid_cumul
         current_test_imgs = merge_images_labels(X_valid_cumul, map_Y_valid_cumul)
@@ -571,7 +574,8 @@ for iteration_total in range(args.nb_runs):
             current_train_imgs = merge_images_labels(np.concatenate(X_protoset_cumuls), map_Y_protoset_cumuls)
             trainset.imgs = trainset.samples = current_train_imgs
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
-                shuffle=True, num_workers=args.num_workers, pin_memory=True)
+                shuffle=True, num_workers=args.num_workers, pin_memory=True,
+                collate_fn=collate_with_soft_targets)
             print('Min and Max of train labels: {}, {}'.format(min(map_Y_protoset_cumuls), max(map_Y_protoset_cumuls)))
             ###############################
             print('Computing accuracy on the protoset...')

--- a/imagenet-class-incremental/class_incremental_cosine_imagenet.py
+++ b/imagenet-class-incremental/class_incremental_cosine_imagenet.py
@@ -34,6 +34,7 @@ from utils_incremental.incremental_train_and_eval_MS import incremental_train_an
 from utils_incremental.incremental_train_and_eval_LF import incremental_train_and_eval_LF
 from utils_incremental.incremental_train_and_eval_MR_LF import incremental_train_and_eval_MR_LF
 from utils_incremental.incremental_train_and_eval_AMR_LF import incremental_train_and_eval_AMR_LF
+from utils_incremental.dataset import collate_with_soft_targets
 
 ######### Modifiable Settings ##########
 parser = argparse.ArgumentParser()
@@ -342,12 +343,14 @@ for iteration_total in range(args.nb_runs):
             #trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size, \
             #    shuffle=False, sampler=train_sampler, num_workers=2)
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size, \
-                shuffle=False, sampler=train_sampler, num_workers=args.num_workers, pin_memory=True)             
+                shuffle=False, sampler=train_sampler, num_workers=args.num_workers, pin_memory=True,
+                collate_fn=collate_with_soft_targets)
         else:
             #trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
             #    shuffle=True, num_workers=2)
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
-                shuffle=True, num_workers=args.num_workers, pin_memory=True)
+                shuffle=True, num_workers=args.num_workers, pin_memory=True,
+                collate_fn=collate_with_soft_targets)
         #testset.test_data = X_valid_cumul.astype('uint8')
         #testset.test_labels = map_Y_valid_cumul
         current_test_imgs = merge_images_labels(X_valid_cumul, map_Y_valid_cumul)

--- a/imagenet-class-incremental/class_incremental_imagenet.py
+++ b/imagenet-class-incremental/class_incremental_imagenet.py
@@ -27,6 +27,7 @@ from utils_incremental.compute_features import compute_features
 from utils_incremental.compute_accuracy import compute_accuracy
 from utils_incremental.compute_confusion_matrix import compute_confusion_matrix
 from utils_incremental.incremental_train_and_eval import incremental_train_and_eval
+from utils_incremental.dataset import collate_with_soft_targets
 
 ######### Modifiable Settings ##########
 parser = argparse.ArgumentParser()
@@ -241,12 +242,14 @@ for iteration_total in range(args.nb_runs):
             #trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size, \
             #    shuffle=False, sampler=train_sampler, num_workers=2)
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size, \
-                shuffle=False, sampler=train_sampler, num_workers=args.num_workers, pin_memory=True)             
+                shuffle=False, sampler=train_sampler, num_workers=args.num_workers, pin_memory=True,
+                collate_fn=collate_with_soft_targets)
         else:
             #trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
             #    shuffle=True, num_workers=2)
             trainloader = torch.utils.data.DataLoader(trainset, batch_size=train_batch_size,
-                shuffle=True, num_workers=args.num_workers, pin_memory=True)
+                shuffle=True, num_workers=args.num_workers, pin_memory=True,
+                collate_fn=collate_with_soft_targets)
         #testset.test_data = X_valid_cumul.astype('uint8')
         #testset.test_labels = map_Y_valid_cumul
         current_test_images = merge_images_labels(X_valid_cumul, map_Y_valid_cumul)


### PR DESCRIPTION
## Summary
- add `collate_with_soft_targets` to stack images/indices and convert labels to one-hot vectors
- use new `collate_fn` in CIFAR and ImageNet training loaders that mix indexed and counterfactual samples

## Testing
- `python -m py_compile utils_incremental/dataset.py cifar100-class-incremental/class_incremental_cifar100.py cifar100-class-incremental/class_incremental_cosine_cifar100.py imagenet-class-incremental/class_incremental_imagenet.py imagenet-class-incremental/class_incremental_cosine_imagenet.py imagenet-class-incremental/cbf_class_incremental_cosine_imagenet.py`


------
https://chatgpt.com/codex/tasks/task_e_6890af29279483229ab60bab5d84e995